### PR TITLE
added describe_stream_summary

### DIFF
--- a/lib/ex_aws/kinesis.ex
+++ b/lib/ex_aws/kinesis.ex
@@ -35,6 +35,12 @@ defmodule ExAws.Kinesis do
     request(:describe_stream, data)
   end
 
+  @doc "Describe stream summary"
+  @spec describe_stream_summary(stream_name :: stream_name) :: ExAws.Operation.JSON.t()
+  def describe_stream_summary(stream_name) do
+    request(:describe_stream_summary, %{"StreamName" => stream_name})
+  end
+
   @doc "Creates stream"
   @spec create_stream(stream_name :: stream_name) :: ExAws.Operation.JSON.t
   @spec create_stream(stream_name :: stream_name, shard_count :: pos_integer) :: ExAws.Operation.JSON.t


### PR DESCRIPTION
added describe_stream_summary to get the shards count of a stream (see [aws-sdk](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_DescribeStreamSummary.html))